### PR TITLE
[Accton][AS7927-50X] Fix Caps status value error

### DIFF
--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/ledi.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/ledi.c
@@ -112,7 +112,7 @@ static onlp_led_info_t linfo[] =
     {
         { ONLP_LED_ID_CREATE(LED_ALARM), "Chassis LED 3 (ALARM LED)", 0, {0} },
         ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_AUTO,
+        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED,
     },
     {
         { ONLP_LED_ID_CREATE(LED_FAN), "Chassis LED 4 (FAN LED)", 0, {0} },


### PR DESCRIPTION
ALARM LED caps show be ON_OFF and RED
<img width="608" height="198" alt="螢幕擷取畫面 2025-10-15 093451" src="https://github.com/user-attachments/assets/17e8afd1-3742-4c38-b60d-872d372f778a" />
