### PR TITLE
 [Accton][AS7927-50X] Feat Use HEX show component version

### DIFF
--- a/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-fpga.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-fpga.c
@@ -668,7 +668,7 @@ static ssize_t status_read(struct device *dev, struct device_attribute *da, char
         case FPGA_VERSION:
             major = ioread8(fpga_ctl->pci_fpga_dev.data_base_addr0 + FPGA_MAJOR_VER_REG);
             minor = ioread8(fpga_ctl->pci_fpga_dev.data_base_addr0 + FPGA_MINOR_VER_REG);
-            ret = sprintf(buf, "%d.%d\n", major, minor);
+            ret = sprintf(buf, "%x.%x\n", major, minor);
             break;
         case CPLD1_VERSION:
             LOCK(&cpld_access_lock);
@@ -680,7 +680,7 @@ static ssize_t status_read(struct device *dev, struct device_attribute *da, char
                               SPI_BUSY_MASK_CPLD1);
             UNLOCK(&cpld_access_lock);
 
-            ret = sprintf(buf, "%d.%d\n", major, minor);
+            ret = sprintf(buf, "%x.%X\n", major, minor);
             break;
         case CPLD2_VERSION:
             LOCK(&cpld_access_lock);
@@ -692,7 +692,7 @@ static ssize_t status_read(struct device *dev, struct device_attribute *da, char
                               SPI_BUSY_MASK_CPLD2);
             UNLOCK(&cpld_access_lock);
 
-            ret = sprintf(buf, "%d.%d\n", major, minor);
+            ret = sprintf(buf, "%x.%x\n", major, minor);
             break;
         case MODULE_PRESENT_1 ... MODULE_PRESENT_48:
         case MODULE_RX_LOS_1 ... MODULE_RX_LOS_48:

--- a/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-sys.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-sys.c
@@ -57,7 +57,7 @@ struct as7927_50x_sys_data {
     unsigned long    last_updated;    /* In jiffies */
     struct ipmi_data ipmi;
     unsigned char    ipmi_resp_eeprom[EEPROM_SIZE];
-    unsigned char    ipmi_resp_cpld[2];
+    unsigned char    ipmi_resp_cpld[4];
     unsigned char    ipmi_tx_data[2];
     struct bin_attribute eeprom;      /* eeprom data */
 };
@@ -254,7 +254,12 @@ static ssize_t show_cpld_version(struct device *dev, struct device_attribute *da
     mutex_unlock(&data->update_lock);
     if (attr->index == DCSCM_CPLD)
         return snprintf(buf, 32, "%x\n", major);
-    minor = data->ipmi_resp_cpld[1];
+    else if (attr->index == COM_E_CPLD){
+        major = data->ipmi_resp_cpld[2];
+        minor = data->ipmi_resp_cpld[3];
+    }
+    else
+        minor = data->ipmi_resp_cpld[1];
     return snprintf(buf, 32, "%x.%x\n", major, minor);
 
 exit:

--- a/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-sys.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-sys.c
@@ -253,9 +253,9 @@ static ssize_t show_cpld_version(struct device *dev, struct device_attribute *da
     major = data->ipmi_resp_cpld[0];
     mutex_unlock(&data->update_lock);
     if (attr->index == DCSCM_CPLD)
-        return snprintf(buf, 32, "%d\n", major);
+        return snprintf(buf, 32, "%x\n", major);
     minor = data->ipmi_resp_cpld[1];
-    return snprintf(buf, 32, "%d.%d\n", major, minor);
+    return snprintf(buf, 32, "%x.%x\n", major, minor);
 
 exit:
     mutex_unlock(&data->update_lock);

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
@@ -43,6 +43,9 @@
 #define FAN_SYSFS_FORMAT_1 "/sys/devices/platform/as7927_50x_fan/hwmon/hwmon%d/%s"
 #define SYS_LED_PATH   "/sys/devices/platform/as7927_50x_led/"
 #define IDPROM_PATH "/sys/bus/platform/devices/as7927_50x_sys/eeprom"
+#define BIOS_VER_PATH  "/sys/devices/virtual/dmi/id/bios_version"
+#define BMC_VER1_PATH  "/sys/devices/platform/ipmi_bmc.0/firmware_revision"
+#define BMC_VER2_PATH  "/sys/devices/platform/ipmi_bmc.0/aux_firmware_revision"
 
 enum onlp_thermal_id {
     THERMAL_RESERVED = 0,

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/sysi.c
@@ -41,13 +41,13 @@
 #define NUM_OF_CPLD_VER                   7
 
 static char* cpld_ver_path[NUM_OF_CPLD_VER] = {
-    "/sys/bus/platform/devices/as7927_50x_sys/come_e_cpld_ver",
-    "/sys/bus/platform/devices/as7927_50x_sys/sys_cpld_ver",
-    "/sys/bus/platform/devices/as7927_50x_sys/dcscm_cpld_ver",
-    "/sys/bus/platform/devices/as7927_50x_sys/fpga_cpld_ver",
-    "/sys/bus/platform/devices/as7927_50x_sys/fan_cpld_ver",
-    "/sys/bus/platform/devices/as7927_50x_fpga/cpld1_version",
-    "/sys/bus/platform/devices/as7927_50x_fpga/cpld2_version",
+    "/sys/bus/platform/devices/as7927_50x_sys/come_e_cpld_ver", /* CPU CPLD */
+    "/sys/bus/platform/devices/as7927_50x_sys/sys_cpld_ver", /* System CPLD */
+    "/sys/bus/platform/devices/as7927_50x_fpga/cpld1_version", /* Port CPLD1 */
+    "/sys/bus/platform/devices/as7927_50x_fpga/cpld2_version", /* Port CPLD2 */
+    "/sys/bus/platform/devices/as7927_50x_sys/dcscm_cpld_ver", /* DC-SCM CPLD */
+    "/sys/bus/platform/devices/as7927_50x_sys/fan_cpld_ver", /* Fan CPLD */
+    "/sys/bus/platform/devices/as7927_50x_sys/fpga_cpld_ver", /* FPGA */
 };
 
 const char*
@@ -108,31 +108,69 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int i, len, ret = ONLP_STATUS_OK;
     char *v[NUM_OF_CPLD_VER] = {NULL};
+    char *bmc_buf = NULL;
+    char *aux_buf = NULL;
+    int bmc_major = 0, bmc_minor = 0;
+    unsigned int bmc_aux[4] = {0};
+    char bmc_ver[16] = ""; 
+    onlp_onie_info_t onie;
+    char *bios_ver = NULL;
 
     for (i = 0; i < AIM_ARRAYSIZE(cpld_ver_path); i++) {
 
         len = onlp_file_read_str(&v[i], cpld_ver_path[i]);
 
-        if (v[i] == NULL || len <= 0) {
-            ret = ONLP_STATUS_E_INTERNAL;
-            break;
+        if (v[i] == NULL || len <= 0)
+            return ONLP_STATUS_E_INTERNAL;
+    }
+
+    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
+    onlp_onie_decode_file(&onie, IDPROM_PATH);
+
+    if ((onlp_file_read_str(&bmc_buf, BMC_VER1_PATH) >= 0) &&
+        (onlp_file_read_str(&aux_buf, BMC_VER2_PATH) >= 0))
+    {
+        bmc_buf[strcspn(bmc_buf, "\n")] = '\0';
+        aux_buf[strcspn(aux_buf, "\n")] = '\0';
+
+        /*
+         * NOTE: The value in /sys/devices/platform/ipmi_bmc.0/firmware_revision is formatted
+         * using "%u.%x" in the kernel driver (see ipmi_msghandler.c::firmware_revision_show).
+         * The second field (after the dot) is output in hexadecimal format and must be parsed
+         * using "%x" from user-space.
+         */
+        if (sscanf(bmc_buf, "%u.%x", &bmc_major, &bmc_minor) == 2 &&
+            sscanf(aux_buf, "0x%x 0x%x 0x%x 0x%x", &bmc_aux[0], &bmc_aux[1], &bmc_aux[2], &bmc_aux[3]) == 4)
+        {
+            snprintf(bmc_ver, sizeof(bmc_ver), "%02X.%02X.%02X",
+                     bmc_major, bmc_minor, bmc_aux[3]);
         }
     }
 
-    if (ret == ONLP_STATUS_OK) {
-        pi->cpld_versions = aim_fstrdup("\r\nCOM_E:%s"
-                                        "\r\nSystem CPLD:%s"
-                                        "\r\nDC-SCM CPLD:%s"
-                                        "\r\nFPGA CPLD:%s"
-                                        "\r\nFan CPLD:%s"
-                                        "\r\nPort CPLD1:%s"
-                                        "\r\nPort CPLD2:%s"
-                                        , v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]);
-    }
+    pi->cpld_versions = aim_fstrdup("\r\n\t   CPU(0x21):%s"
+                                    "\r\n\t   Main(0x61):%s"
+                                    "\r\n\t   Main(0x62):%s"
+                                    "\r\n\t   Main(0x63):%s"
+                                    "\r\n\t   Carrier(0x60):%s"
+                                    "\r\n\t   Fan(0x33):%s"
+                                    , v[0], v[1], v[2], v[3], v[4], v[5]);
+                                    
+                                    
+                                    
+pi->other_versions = aim_fstrdup("\r\n\t   FPGA(0x60):%s"
+                                 "\r\n\t   BIOS: %s"
+                                 "\r\n\t   ONIE: %s"
+                                 "\r\n\t   BMC: %s",
+                                 v[6], bios_ver, onie.onie_version, bmc_ver);
 
     for (i = 0; i < AIM_ARRAYSIZE(v); i++) {
         AIM_FREE_IF_PTR(v[i]);
     }
+
+    AIM_FREE_IF_PTR(bmc_buf);
+    AIM_FREE_IF_PTR(aux_buf);
+    AIM_FREE_IF_PTR(bios_ver);
+    onlp_onie_info_free(&onie);
 
     return ret;
 }
@@ -141,6 +179,7 @@ void
 onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
     aim_free(pi->cpld_versions);
+    aim_free(pi->other_versions);
 }
 
 int


### PR DESCRIPTION
1. [Accton][AS7927-50X] Feat show BIOS, ONIE and BMC version
2. [Accton][AS7927-50X] Modify Use HEX storage component version
3. [Accton][AS7927-50X] Fix the CPU CPLD version show

<img width="1030" height="754" alt="image" src="https://github.com/user-attachments/assets/8b111708-8d12-4c9a-a039-3c052af62140" />

