### PR TITLE
[Accton][AS7927-50X] implement dynamic thermal thresholds and PSU type detection

### DIFF
--- a/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-psu.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/modules/builds/src/x86-64-accton-as7927-50x-psu.c
@@ -198,6 +198,7 @@ static struct platform_driver as7927_50x_psu_driver = {
 #define PSU_FAN_INPUT_ATTR_ID(index) PSU##index##_FAN_INPUT
 #define PSU_FAN_DIR_ATTR_ID(index) PSU##index##_FAN_DIR
 
+#define PSU_TYPE_ATTR_ID(index) PSU##index##_TYPE
 #define PSU_FAN_SPEED_MAX_ATTR_ID(index) PSU##index##_FAN_SPEED_MAX
 #define PSU_TEMP1_INPUT_MAX_ATTR_ID(index) PSU##index##_TEMP1_INPUT_MAX
 #define PSU_TEMP1_INPUT_MIN_ATTR_ID(index) PSU##index##_TEMP1_INPUT_MIN
@@ -234,6 +235,7 @@ static struct platform_driver as7927_50x_psu_driver = {
     PSU_TEMP3_INPUT_ATTR_ID(psu_id), \
     PSU_FAN_INPUT_ATTR_ID(psu_id), \
     PSU_FAN_DIR_ATTR_ID(psu_id), \
+    PSU_TYPE_ATTR_ID(psu_id), \
     PSU_FAN_SPEED_MAX_ATTR_ID(psu_id), \
     PSU_TEMP1_INPUT_MAX_ATTR_ID(psu_id), \
     PSU_TEMP1_INPUT_MIN_ATTR_ID(psu_id), \
@@ -296,6 +298,8 @@ enum as7927_50x_psu_sysfs_attrs {
                                 PSU##index##_FAN_INPUT); \
     static SENSOR_DEVICE_ATTR(psu##index##_fan_dir, S_IRUGO, show_string, NULL,\
                                 PSU##index##_FAN_DIR); \
+    static SENSOR_DEVICE_ATTR(psu##index##_type, S_IRUGO, \
+                        show_psu_info, NULL, PSU##index##_TYPE); \
     static SENSOR_DEVICE_ATTR(psu##index##_fan_speed_max, S_IRUGO, \
                         show_psu_info, NULL, PSU##index##_FAN_SPEED_MAX); \
     static SENSOR_DEVICE_ATTR(psu##index##_temp1_input_max, S_IRUGO, \
@@ -349,6 +353,7 @@ enum as7927_50x_psu_sysfs_attrs {
     &sensor_dev_attr_psu##index##_temp3_input.dev_attr.attr, \
     &sensor_dev_attr_psu##index##_fan1_input.dev_attr.attr, \
     &sensor_dev_attr_psu##index##_fan_dir.dev_attr.attr, \
+    &sensor_dev_attr_psu##index##_type.dev_attr.attr, \
     &sensor_dev_attr_psu##index##_fan_speed_max.dev_attr.attr, \
     &sensor_dev_attr_psu##index##_temp1_input_max.dev_attr.attr, \
     &sensor_dev_attr_psu##index##_temp1_input_min.dev_attr.attr, \
@@ -681,6 +686,11 @@ static ssize_t show_psu_info(struct device *dev, struct device_attribute *da,
     present = !!(data->ipmi_resp[pid].status[PSU_PRESENT]);
 
     switch (attr->index) {
+    case PSU1_TYPE:
+    case PSU2_TYPE:
+        VALIDATE_PRESENT_RETURN(pid);
+        value = (u32)data->ipmi_resp[pid].info[PSU_TYPE];
+        break;
     case PSU1_FAN_SPEED_MAX:
     case PSU2_FAN_SPEED_MAX:
         VALIDATE_PRESENT_RETURN(pid);

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.c
@@ -27,6 +27,29 @@
 #include <onlplib/file.h>
 #include "platform_lib.h"
 
+enum onlp_psu_type onlp_get_psu_type(int pid)
+{
+    int hwmon_idx;
+    int val;
+    char file[32];
+    enum onlp_psu_type type = PSU_TYPE_DC;
+
+    hwmon_idx = onlp_get_psu_hwmon_idx(pid);
+    if (hwmon_idx < 0) {
+        return type;
+    }
+
+    snprintf(file, sizeof(file), "psu%d_type", pid);
+
+    if (onlp_file_read_int(&val, PSU_SYSFS_FORMAT_1, hwmon_idx, file) == 0) {
+        if (val >= 0 && val < PSU_TYPE_COUNT) {
+            type = (enum onlp_psu_type)val;
+        }
+    }
+
+    return type;
+}
+
 enum onlp_fan_dir onlp_get_fan_dir(int fid)
 {
     int len = 0;

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
@@ -90,12 +90,19 @@ enum onlp_fan_dir {
     FAN_DIR_COUNT
 };
 
+enum onlp_psu_type {
+    PSU_TYPE_DC,
+    PSU_TYPE_AC,
+    PSU_TYPE_COUNT
+};
+
 typedef enum as7927_50x_platform_id {
     as7927_50x,
     PID_UNKNOWN
 } as7927_50x_platform_id_t;
 
 enum onlp_fan_dir onlp_get_fan_dir(int fid);
+enum onlp_psu_type onlp_get_psu_type(int pid);
 int onlp_get_psu_hwmon_idx(int pid);
 int onlp_get_fan_hwmon_idx(void);
 

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/thermali.c
@@ -61,105 +61,93 @@ static char* devfiles__[] = { /* must map with onlp_thermal_id */
     "/sys/devices/platform/as7927_50x_psu*psu2_temp3_input"
 };
 
-/* Static values */
-static onlp_thermal_info_t tinfo[] = {
+typedef struct {
+    int warning;
+    int error;
+    int shutdown;
+} platform_thermal_thresholds_t;
+
+typedef struct {
+    platform_thermal_thresholds_t f2b;
+    platform_thermal_thresholds_t b2f;
+} thermal_dir_thresholds_t;
+
+static thermal_dir_thresholds_t threshold_dict[] = {
+    [8]  = { {45100, 50100, 53100}, {50750, 55750, 58750} }, /* MB_FrontLeft */
+    [9]  = { {43900, 48900, 51900}, {47130, 52130, 55130} }, /* I/OB */
+    [10] = { {45300, 50300, 53300}, {48250, 53250, 56250} }, /* MB_FrontRight */
+    [11] = { {47000, 52000, 55000}, {52380, 57380, 60380} }, /* MB_RearLeft */
+    [12] = { {78300, 83300, 86300}, {80130, 85130, 88130} }, /* MAC_DiodeCore */
+    [13] = { {85600, 90600, 93600}, {88060, 93060, 96060} }, /* MAC_DiodeNif100 */
+    [14] = { {83500, 88500, 91500}, {85560, 90560, 93560} }, /* MAC_DiodeNif50 */
+    [15] = { {82900, 87900, 90900}, {85310, 90310, 93310} }, /* MAC_DiodeSch */
+    [16] = { {46600, 51600, 54600}, {45000, 50000, 53000} }, /* FB_FrontRight */
+    [17] = { {43900, 48900, 51900}, {44380, 49380, 52380} }  /* FB_FrontLeft */
+};
+
+typedef struct {
+    platform_thermal_thresholds_t dc;
+    platform_thermal_thresholds_t ac;
+} thermal_psu_type_thresholds_t;
+
+static thermal_psu_type_thresholds_t psu_threshold_dict[] = {
+    [1] = { { 83000,  86000,  89000}, {100000, 105000, 108000} },  /* PSU_TEMP1 */
+    [2] = { {100000, 105000, 108000}, {110000, 115000, 118000} },  /* PSU_TEMP2 */
+    [3] = { {110000, 115000, 118000}, { 70000,  75000,  78000} }   /* PSU_TEMP3 */
+};
+
+static onlp_thermal_info_t tinfo_base[] = {
     { }, /* Not used */
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_CPU_CORE), "CPU Core 1", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_CPU_CORE), "CPU Core 2", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_CPU_CORE), "CPU Core 3", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_4_CPU_CORE), "CPU Core 4", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_5_CPU_CORE), "CPU Core 5", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_CPU_CORE), "CPU DIE", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, {61000, 66000, 69000} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_CPU_CORE), "CPU Core 1", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, {61000, 66000, 69000} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_CPU_CORE), "CPU Core 2", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, {61000, 66000, 69000} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_4_CPU_CORE), "CPU Core 3", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, {61000, 66000, 69000} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_5_CPU_CORE), "CPU Core 4", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, {61000, 66000, 69000} },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_CARRIER_BROAD), "CB_RearLefttemp(0x48)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_CARRIER_BROAD), "CB_FrontLeft_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD), "MB_FrontLeft_temp(0x4A)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_IO_BROAD), "I/OB_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD), "MB_FrontRight_temp(0x4C)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD), "MB_RearLeft_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_7_ON_MAC_BROAD), "MAC_DiodeCore_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_8_ON_MAC_BROAD), "MAC_DiodeNif100_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_9_ON_MAC_BROAD), "MAC_DiodeNif50_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_10_ON_MAC_BROAD), "MAC_DiodeSch_temp(0x49)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_FAN_BROAD), "FB_FrontRight_temp(0x4D)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_FAN_BROAD), "FB_FrontLeft_temp(0x4E)", 0, {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU1), "PSU-1 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU1), "PSU-1 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU1), "PSU-1 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU2), "PSU-2 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU2), "PSU-2 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    },
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU2), "PSU-2 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-        ONLP_THERMAL_STATUS_PRESENT,
-        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-    }
+        ONLP_THERMAL_STATUS_PRESENT, ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS }
 };
 
 /*
- * This will be called to intiialize the thermali subsystem.
+ * This will be called to initialize the thermali subsystem.
  */
 int
 onlp_thermali_init(void)
@@ -181,10 +169,40 @@ int
 onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int tid;
+    int psu_id;
+    int psu_type;
+    int fan_dir;
+    int sensor_idx;
+    platform_thermal_thresholds_t *th;
+
     VALIDATE(id);
 
     tid = ONLP_OID_ID_GET(id);
-    *info = tinfo[tid];
+    if (tid <= 0 || tid >= THERMAL_COUNT) {
+        return ONLP_STATUS_E_INVALID;
+    }
+
+    *info = tinfo_base[tid];
+
+    if (tid >= 8 && tid <= 17) {
+        fan_dir = onlp_get_fan_dir(1);
+        th = (fan_dir == FAN_DIR_B2F) ? &threshold_dict[tid].b2f : &threshold_dict[tid].f2b;
+
+        info->thresholds.warning = th->warning;
+        info->thresholds.error = th->error;
+        info->thresholds.shutdown = th->shutdown;
+    } 
+    else if (tid >= 18 && tid <= 23) {
+        psu_id = (tid <= 20) ? 1 : 2;
+        psu_type = onlp_get_psu_type(psu_id); 
+
+        sensor_idx = (tid - 18) % 3 + 1;
+        th = (psu_type == PSU_TYPE_DC) ? &psu_threshold_dict[sensor_idx].dc : &psu_threshold_dict[sensor_idx].ac;
+
+        info->thresholds.warning = th->warning;
+        info->thresholds.error = th->error;
+        info->thresholds.shutdown = th->shutdown;
+    }
 
     return onlp_file_read_int(&info->mcelsius, devfiles__[tid]);
 }


### PR DESCRIPTION
- psu: Add `psuX_type` sysfs attribute to expose power supply type (AC/DC).
- onlp/platform_lib: Introduce `onlp_get_psu_type()` to retrieve the PSU type via sysfs.
- onlp/thermali: Refactor thermal info structure to support dynamic threshold assignment.
  - Apply specific warning/error/shutdown thresholds for board and MAC sensors based on fan airflow direction (F2B vs B2F).
  - Apply specific thresholds for PSU thermal sensors based on the detected PSU type (DC vs AC).
  - Update CPU thermal sensor descriptions (e.g., renamed to "CPU DIE").