### PR TITLE
[Accton][AS7927-50X]: enable CONFIG_VMD to resolve NVMe boot failur

### DIFF
--- a/packages/base/any/kernels/5.4-lts/configs/x86_64-all/x86_64-all.config
+++ b/packages/base/any/kernels/5.4-lts/configs/x86_64-all/x86_64-all.config
@@ -1263,7 +1263,7 @@ CONFIG_HOTPLUG_PCI=y
 #
 # end of Cadence PCIe controllers support
 
-# CONFIG_VMD is not set
+CONFIG_VMD=y
 
 #
 # DesignWare PCI Core Support


### PR DESCRIPTION
- Set CONFIG_VMD=y in 5.4-lts x86_64-all.config.
- Fixes the "loader(aborted)" boot crash on platforms like Accton AS7927-50X (CPUC-ICXR).
- Allows the kernel to correctly detect NVMe SSDs located behind Intel VMD controllers, ensuring ONL partitions can be mounted successfully.