### PR TITLE
[Accton][AS7927-50X] refactor: move XCVR thermal functions to platform_lib

### DIFF
--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.c
@@ -23,8 +23,10 @@
  *
  *
  ***********************************************************/
+#include <string.h>
 #include <onlp/onlp.h>
 #include <onlplib/file.h>
+#include <onlp/platformi/sfpi.h>
 #include "platform_lib.h"
 
 enum onlp_psu_type onlp_get_psu_type(int pid)
@@ -129,4 +131,272 @@ int onlp_get_fan_hwmon_idx(void)
     }
 
     return -1;
+}
+
+int
+get_xcvr_presence(void)
+{
+    onlp_sfp_bitmap_t bitmap;
+    onlp_sfp_bitmap_t_init(&bitmap);
+    onlp_sfp_presence_bitmap_get(&bitmap);
+    return !(AIM_BITMAP_COUNT(&bitmap) == 0);
+}
+
+// =======================================================
+// SFF-8472 (SFP) Temperature and Alarm Getters
+// =======================================================
+int
+get_sff8472_temp(int port, int *temp)
+{
+    int value;
+    int16_t port_temp;
+
+    /* SFF-8472 DDM Support Check is at Address A0h (0x50), Offset 92 */
+    value = onlp_sfpi_dev_readb(port, 0x50, 92);
+    if (value < 0 || !(value & 0x40)) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+
+    /* SFF-8472 Temperature is at Address A2h (0x51), Offset 96-97 */
+    value = onlp_sfpi_dev_readb(port, 0x51, 96);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x51, 97);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (port_temp | (int16_t)(value & 0xFF));
+
+    *temp = (int)port_temp * 1000 / 256;
+    return ONLP_STATUS_OK;
+}
+
+int
+get_sff8472_temp_alarm(int port, int *alarm)
+{
+    int value;
+    int16_t port_alarm;
+
+    /* SFF-8472 High Alarm is at Address A2h (0x51), Offset 00-01 */
+    value = onlp_sfpi_dev_readb(port, 0x51, 0);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x51, 1);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
+
+    *alarm = (int)port_alarm * 1000 / 256;
+    return ONLP_STATUS_OK;
+}
+
+// =======================================================
+// SFF-8436 (QSFP+) Temperature and Alarm Getters
+// =======================================================
+int
+get_sff8436_temp(int port, int *temp)
+{
+    int value;
+    int16_t port_temp;
+
+    /* QSFP+ Temperature is at Address A0h (0x50), Page 00h, Offset 22-23 */
+    value = onlp_sfpi_dev_readb(port, 0x50, 22);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 23);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (port_temp | (int16_t)(value & 0xFF));
+
+    *temp = (int)port_temp * 1000 / 256;
+    return ONLP_STATUS_OK;
+}
+
+int
+get_sff8436_temp_alarm(int port, int *alarm)
+{
+    int value;
+    int16_t port_alarm;
+
+    /* QSFP+ Memory model check is at Address A0h (0x50), Offset 2 */
+    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
+    if (value < 0 || (value & 0x04)) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+
+    /* QSFP+ Temp High Alarm is at Page 03h，Offset 128-129 */
+    if (onlp_sfpi_dev_writeb(port, 0x50, 127, 0x03) < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 128);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 129);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
+    *alarm = (int)port_alarm * 1000 / 256;
+
+    onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+    return ONLP_STATUS_OK;
+}
+
+// =======================================================
+// CMIS (QSFP-DD) Temperature and Alarm Getters
+// =======================================================
+int get_cmis_temp(int port, int *temp)
+{
+    int value;
+    int16_t port_temp;
+
+    /* CMIS Temperature is at Address A0h (0x50), Page 00h, Offset 14-15 */
+    value = onlp_sfpi_dev_readb(port, 0x50, 14);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 15);
+    if (value < 0) {
+        *temp = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_temp = (port_temp | (int16_t)(value & 0xFF));
+
+    *temp = (int)port_temp * 1000 / 256;
+    return ONLP_STATUS_OK;
+}
+
+int get_cmis_temp_alarm(int port, int *alarm)
+{
+    int value;
+    int16_t port_alarm;
+
+    /* CMIS Memory model check is at Address A0h (0x50), Offset 2 */
+    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
+    if (value < 0 || (value & 0x80)) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+
+    /* CMIS Temp High Alarm is at Page 02h，Offset 128-129 */
+    if (onlp_sfpi_dev_writeb(port, 0x50, 127, 0x02) < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        return ONLP_STATUS_E_MISSING;
+    }
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 128);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (int16_t)((value & 0xFF) << 8);
+
+    value = onlp_sfpi_dev_readb(port, 0x50, 129);
+    if (value < 0) {
+        *alarm = ONLP_STATUS_E_MISSING;
+        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+        return ONLP_STATUS_E_MISSING;
+    }
+    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
+    *alarm = (int)port_alarm * 1000 / 256;
+
+    onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
+    return ONLP_STATUS_OK;
+}
+
+int
+get_xcvr_temp(temp_reader_data_t *temp)
+{
+    int ret = ONLP_STATUS_OK;
+    int value, port;
+    int port_temp = ONLP_STATUS_E_MISSING, port_alarm = ONLP_STATUS_E_MISSING;
+
+    memset(temp, 0, sizeof(temp_reader_data_t));
+
+    if (!get_xcvr_presence()) {
+        return ONLP_STATUS_OK;
+    }
+
+    for (port = 1; port <= PORT_NUM; port++) {
+        temp->ports[port].temp = ONLP_STATUS_E_MISSING;
+        temp->ports[port].high_alarm = ONLP_STATUS_E_MISSING;
+        temp->ports[port].present = 0;
+
+        port_temp = ONLP_STATUS_E_MISSING;
+        port_alarm = ONLP_STATUS_E_MISSING;
+
+        if (onlp_sfpi_is_present(port) != 1) {
+            continue;
+        }
+
+        temp->ports[port].present = 1;
+
+        value = onlp_sfpi_dev_readb(port, 0x50, 0);
+        if (value < 0) {
+            AIM_LOG_ERROR("Unable to get read port(%d) eeprom\r\n", port);
+            continue;
+        }
+
+        if (value == 0x18 || value == 0x19 || value == 0x1E) {
+            ret = get_cmis_temp(port, &port_temp);
+            if (ret != ONLP_STATUS_OK) {
+                continue;
+            }
+            get_cmis_temp_alarm(port, &port_alarm);
+        }
+        else if (value == 0x0C || value == 0x0D || value == 0x11 || value ==  0xE1) {
+            ret = get_sff8436_temp(port, &port_temp);
+            if (ret != ONLP_STATUS_OK) {
+                continue;
+            }
+            get_sff8436_temp_alarm(port, &port_alarm);
+        }
+        else if(value == 0x03 || value == 0x0b) {
+            ret = get_sff8472_temp(port, &port_temp);
+            if (ret != ONLP_STATUS_OK) {
+                continue;
+            }
+            get_sff8472_temp_alarm(port, &port_alarm);
+        }
+        else {
+            continue;
+        }
+
+        temp->ports[port].temp = port_temp;
+        temp->ports[port].high_alarm = (port_alarm != ONLP_STATUS_E_MISSING) ? port_alarm : 75000;
+    }
+
+    return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/platform_lib.h
@@ -104,10 +104,32 @@ typedef enum as7927_50x_platform_id {
     PID_UNKNOWN
 } as7927_50x_platform_id_t;
 
+#define PORT_NUM                50
+#define LAST_OF_SFP_PORT        48
+
+typedef struct port_thermal_data {
+    int present;
+    int temp;
+    int high_alarm;
+} port_thermal_data_t;
+
+typedef struct temp_reader_data {
+    port_thermal_data_t ports[PORT_NUM + 1];
+} temp_reader_data_t;
+
 enum onlp_fan_dir onlp_get_fan_dir(int fid);
 enum onlp_psu_type onlp_get_psu_type(int pid);
 int onlp_get_psu_hwmon_idx(int pid);
 int onlp_get_fan_hwmon_idx(void);
+
+int get_xcvr_presence(void);
+int get_sff8472_temp(int port, int *temp);
+int get_sff8472_temp_alarm(int port, int *alarm);
+int get_sff8436_temp(int port, int *temp);
+int get_sff8436_temp_alarm(int port, int *alarm);
+int get_cmis_temp(int port, int *temp);
+int get_cmis_temp_alarm(int port, int *alarm);
+int get_xcvr_temp(temp_reader_data_t *temp);
 
 #define AIM_FREE_IF_PTR(p) \
     do \

--- a/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7927-50x/onlp/builds/x86_64_accton_as7927_50x/module/src/sysi.c
@@ -39,25 +39,12 @@
 #include "x86_64_accton_as7927_50x_log.h"
 
 #define NUM_OF_CPLD_VER          7
-#define PORT_NUM                50
-#define LAST_OF_SFP_PORT        48
 #define BMC_FILE_RETRY_COUNT     3    // Retry count for file read/write operations
 #define BMC_FILE_RETRY_DELAY_S   1    // Delay between retries (in seconds, 1s)
 
 #define MODULE_EFUSE_FORMAT        "/sys/bus/platform/devices/as7927_50x_fpga/module_efuse_%d"
 
-typedef struct port_thermal_data {
-    int present;
-    int temp;
-    int high_alarm;
-} port_thermal_data_t;
-
-typedef struct temp_reader_data {
-    port_thermal_data_t ports[PORT_NUM + 1];
-} temp_reader_data_t;
-
-int onlp_sysi_get_xcvr_temp(temp_reader_data_t *temp);
-int onlp_sysi_xcvr_over_temp_protector(int port);
+int xcvr_over_temp_protector(int port);
 
 enum temp_sensors {
     TEMP_SENSOR_XCVR,
@@ -84,11 +71,11 @@ struct thermal_policy_manager {
 struct thermal_policy_manager tp_mgr = {
     .temp_hdlr = {
         .temp_readers = {
-            [TEMP_SENSOR_XCVR] = onlp_sysi_get_xcvr_temp
+            [TEMP_SENSOR_XCVR] = get_xcvr_temp
         }
     },
     .otp_hdlr = {
-        .otp_writer = onlp_sysi_xcvr_over_temp_protector
+        .otp_writer = xcvr_over_temp_protector
     }
 };
 
@@ -225,15 +212,6 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     return ret;
 }
 
-int 
-onlp_sysi_get_xcvr_presence(void)
-{
-    onlp_sfp_bitmap_t bitmap;
-    onlp_sfp_bitmap_t_init(&bitmap);
-    onlp_sfp_presence_bitmap_get(&bitmap);
-    return !(AIM_BITMAP_COUNT(&bitmap) == 0);
-}
-
 void
 onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
@@ -241,268 +219,8 @@ onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
     aim_free(pi->other_versions);
 }
 
-// =======================================================
-// SFF-8472 (SFP) Temperature and Alarm Getters
-// =======================================================
 int 
-onlp_sysi_get_sff8472_temp(int port, int *temp)
-{
-    int value;
-    int16_t port_temp;
-
-    /* SFF-8472 DDM Support Check is at Address A0h (0x50), Offset 92 */
-    value = onlp_sfpi_dev_readb(port, 0x50, 92);
-    if (value < 0 || !(value & 0x40)) { 
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-
-    /* SFF-8472 Temperature is at Address A2h (0x51), Offset 96-97 */
-    value = onlp_sfpi_dev_readb(port, 0x51, 96);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x51, 97);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (port_temp | (int16_t)(value & 0xFF));
-
-    *temp = (int)port_temp * 1000 / 256;
-    return ONLP_STATUS_OK;
-}
-
-int 
-onlp_sysi_get_sff8472_temp_alarm(int port, int *alarm)
-{
-    int value;
-    int16_t port_alarm;
-
-    /* SFF-8472 High Alarm is at Address A2h (0x51), Offset 00-01 */
-    value = onlp_sfpi_dev_readb(port, 0x51, 0); 
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x51, 1);
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
-
-    *alarm = (int)port_alarm * 1000 / 256;
-    return ONLP_STATUS_OK;
-}
-
-// =======================================================
-// SFF-8436 (QSFP+) Temperature and Alarm Getters
-// =======================================================
-int 
-onlp_sysi_get_sff8436_temp(int port, int *temp)
-{
-    int value;
-    int16_t port_temp;
-
-    /* QSFP+ Temperature is at Address A0h (0x50), Page 00h, Offset 22-23 */
-    value = onlp_sfpi_dev_readb(port, 0x50, 22);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 23);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (port_temp | (int16_t)(value & 0xFF));
-
-    *temp = (int)port_temp * 1000 / 256;
-    return ONLP_STATUS_OK;
-}
-
-int 
-onlp_sysi_get_sff8436_temp_alarm(int port, int *alarm)
-{
-    int value;
-    int16_t port_alarm;
-
-    /* QSFP+ Memory model check is at Address A0h (0x50), Offset 2 */
-    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
-    if (value < 0 || (value & 0x04)) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-
-    /* QSFP+ Temp High Alarm is at Page 03h，Offset 128-129 */
-    if (onlp_sfpi_dev_writeb(port, 0x50, 127, 0x03) < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 128);
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 129);
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
-    *alarm = (int)port_alarm * 1000 / 256;
-
-    onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-    return ONLP_STATUS_OK;
-}
-
-// =======================================================
-// CMIS (QSFP-DD) Temperature and Alarm Getters
-// =======================================================
-int onlp_sysi_get_cmis_temp(int port, int *temp)
-{
-    int value;
-    int16_t port_temp;
-
-
-    /* CMIS Temperature is at Address A0h (0x50), Page 00h, Offset 14-15 */
-    value = onlp_sfpi_dev_readb(port, 0x50, 14);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 15);
-    if (value < 0) {
-        *temp = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_temp = (port_temp | (int16_t)(value & 0xFF));
-
-    *temp = (int)port_temp * 1000 / 256;
-    return ONLP_STATUS_OK;
-}
-
-int onlp_sysi_get_cmis_temp_alarm(int port, int *alarm)
-{
-    int value;
-    int16_t port_alarm;
-
-    /* CMIS Memory model check is at Address A0h (0x50), Offset 2 */
-    value = onlp_sfpi_dev_readb(port, 0x50, 0x2);
-    if (value < 0 || (value & 0x80)) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-
-    /* CMIS Temp High Alarm is at Page 02h，Offset 128-129 */
-    if (onlp_sfpi_dev_writeb(port, 0x50, 127, 0x02) < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        return ONLP_STATUS_E_MISSING;
-    }
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 128);
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (int16_t)((value & 0xFF) << 8);
-
-    value = onlp_sfpi_dev_readb(port, 0x50, 129);
-    if (value < 0) {
-        *alarm = ONLP_STATUS_E_MISSING;
-        onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-        return ONLP_STATUS_E_MISSING;
-    }
-    port_alarm = (port_alarm | (int16_t)(value & 0xFF));
-    *alarm = (int)port_alarm * 1000 / 256;
-
-    onlp_sfpi_dev_writeb(port, 0x50, 127, 0x00);
-    return ONLP_STATUS_OK;
-}
-
-int 
-onlp_sysi_get_xcvr_temp(temp_reader_data_t *temp)
-{
-    int ret = ONLP_STATUS_OK;
-    int value, port;
-    int port_temp = ONLP_STATUS_E_MISSING, port_alarm = ONLP_STATUS_E_MISSING;
-
-    memset(temp, 0, sizeof(temp_reader_data_t));
-
-    if (!onlp_sysi_get_xcvr_presence()) {
-        return ONLP_STATUS_OK;
-    }
-
-    for (port = 1; port <= PORT_NUM; port++) {
-        temp->ports[port].temp = ONLP_STATUS_E_MISSING;
-        temp->ports[port].high_alarm = ONLP_STATUS_E_MISSING;
-        temp->ports[port].present = 0;
-
-        port_temp = ONLP_STATUS_E_MISSING;
-        port_alarm = ONLP_STATUS_E_MISSING;
-
-        if (onlp_sfpi_is_present(port) != 1) {
-            continue;
-        }
-
-        temp->ports[port].present = 1;
-
-        value = onlp_sfpi_dev_readb(port, 0x50, 0);
-        if (value < 0) {
-            AIM_LOG_ERROR("Unable to get read port(%d) eeprom\r\n", port);
-            continue;
-        }
-
-        if (value == 0x18 || value == 0x19 || value == 0x1E) {
-            ret = onlp_sysi_get_cmis_temp(port, &port_temp);
-            if (ret != ONLP_STATUS_OK) {
-                continue;
-            }
-            onlp_sysi_get_cmis_temp_alarm(port, &port_alarm);
-        }
-        else if (value == 0x0C || value == 0x0D || value == 0x11 || value ==  0xE1) {
-            ret = onlp_sysi_get_sff8436_temp(port, &port_temp);
-            if (ret != ONLP_STATUS_OK) {
-                continue;
-            }
-            onlp_sysi_get_sff8436_temp_alarm(port, &port_alarm);
-        }
-        else if(value == 0x03 || value == 0x0b) {
-            ret = onlp_sysi_get_sff8472_temp(port, &port_temp);
-            if (ret != ONLP_STATUS_OK) {
-                continue;
-            }
-            onlp_sysi_get_sff8472_temp_alarm(port, &port_alarm);
-        }
-        else {
-            continue;
-        }
-
-        temp->ports[port].temp = port_temp;
-        temp->ports[port].high_alarm = (port_alarm != ONLP_STATUS_E_MISSING) ? port_alarm : 75000;
-    }
-
-    return ONLP_STATUS_OK;
-}
-
-int 
-onlp_sysi_xcvr_over_temp_protector(int port)
+xcvr_over_temp_protector(int port)
 {
     int ret = ONLP_STATUS_E_INTERNAL;
     AIM_SYSLOG_CRIT("Temperature critical", "OTP Action",


### PR DESCRIPTION
Refactor transceiver thermal monitoring functions out of sysi.c into platform_lib.c for better reusability and separation of concerns.

Key changes include:
- onlp: Rename XCVR thermal functions from onlp_sysi_* prefix to generic names (get_xcvr_temp, get_sff8472_temp, get_cmis_temp, etc.) since they are not ONLP platform API implementations.
- onlp: Move XCVR temperature getters (SFF-8472, SFF-8436, CMIS), presence check, and related structs (port_thermal_data_t, temp_reader_data_t) to platform_lib.c/.h for cross-module reuse.
- onlp: Rename xcvr_over_temp_protector to drop onlp_sysi_ prefix, keeping it in sysi.c as it is tightly coupled to the thermal policy manager logic.
- onlp: Move PORT_NUM and LAST_OF_SFP_PORT defines to platform_lib.h.